### PR TITLE
Replace autoconf with automake for building Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y --no-install-recommends install  \
            python3-dev \
            unzip \
            vim \
-           autoconf \
+           automake \
            libtool
 
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Building on Apple M1 seems to require automake instead of autoconf?

Error with install: autoreconf fails to run aclocal #24 
https://github.com/buffer/pylibemu/issues/24