### PR TITLE
Feature/quay image tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,9 +33,14 @@ jobs:
     - name: Set Variables
       shell: bash
       run: |
-        echo "No OVERRIDE_TAG_NAME input provided, defaulting to current branch/tag name..."
-        echo "IMAGE_TAG=$(echo ${GITHUB_REF#refs/*/} | tr / _)"
-        echo "IMAGE_TAG=$(echo ${GITHUB_REF#refs/*/} | tr / _)" >> $GITHUB_ENV
+        BRANCH = $(echo ${GITHUB_REF#refs/*/} | tr / _)
+        if [[ $BRANCH == 'main' ]]; then
+          IMAGE_TAG=latest
+        else
+          IMAGE_TAG=$BRANCH
+        fi
+        echo "IMAGE_TAG=$IMAGE_TAG"
+        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
     - name: Build
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Set Variables
       shell: bash
       run: |
-        BRANCH = $(echo ${GITHUB_REF#refs/*/} | tr / _)
+        BRANCH=$(echo ${GITHUB_REF#refs/*/} | tr / _)
         if [[ $BRANCH == 'main' ]]; then
           IMAGE_TAG=latest
         else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,20 +30,21 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-    - name: Set Variables
-      shell: bash
+    - name: Build and push image
       run: |
+        # Set Image tag to the branch name
         BRANCH=$(echo ${GITHUB_REF#refs/*/} | tr / _)
-        if [[ $BRANCH == 'main' ]]; then
-          IMAGE_TAG=latest
-        else
-          IMAGE_TAG=$BRANCH
-        fi
         echo "IMAGE_TAG=$IMAGE_TAG"
-        echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
-    - name: Build
-      run: |
+        # Login to Quay.io and build image
         docker login quay.io
-        docker build -t quay.io/ohsu-comp-bio/aced-etl:${{ env.IMAGE_TAG }} ./etl-job
-        docker push quay.io/ohsu-comp-bio/aced-etl:${{ env.IMAGE_TAG }}
+        REPO=quay.io/ohsu-comp-bio/aced-etl
+        docker build -t $REPO:${{ env.IMAGE_TAG }} ./etl-job
+        
+        # Add 'latest' tag to 'main' image
+        if [[ $IMAGE_TAG == 'main' ]]; then
+          docker image tag $REPO:main $REPO:latest
+        fi
+
+        # Push the tagged image to Quay.io
+        docker push --all-tags $REPO

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,15 +34,15 @@ jobs:
       run: |
         # Set Image tag to the branch name
         BRANCH=$(echo ${GITHUB_REF#refs/*/} | tr / _)
-        echo "IMAGE_TAG=$IMAGE_TAG"
+        REPO=quay.io/ohsu-comp-bio/aced-etl
+        echo "Setting image tag to $REPO:$BRANCH"
 
         # Login to Quay.io and build image
         docker login quay.io
-        REPO=quay.io/ohsu-comp-bio/aced-etl
-        docker build -t $REPO:${{ env.IMAGE_TAG }} ./etl-job
+        docker build -t $REPO:$BRANCH ./etl-job
         
         # Add 'latest' tag to 'main' image
-        if [[ $IMAGE_TAG == 'main' ]]; then
+        if [[ $BRANCH == 'main' ]]; then
           docker image tag $REPO:main $REPO:latest
         fi
 


### PR DESCRIPTION
# Changes

- Builds are now triggered on every push (and through the 'Run Workflow' button on the [Actions page](https://github.com/ACED-IDP/aced_etl_pod/actions/workflows/build.yaml))
- Quay images are tagged by the Branch name of the pushed commit (with slashes replaced by underscores*)

| Branch                 | Quay Image Tag         |
| ---------------------- | ---------------------- |
| main                   | main, latest                 |
| development            | development            |
| feature/elasticsearch7 | feature_elasticsearch7 |

This follows the same convention as uc-cdis (e.g. [Fence on Quay.io](https://quay.io/repository/cdis/fence?tab=tags)), with the added benefit of defaulting to the 'main' or 'latest' branch if no tag is specified.

##  Additional Resources

- [uc-cdis common image build file](https://github.com/uc-cdis/.github/blob/master/.github/workflows/image_build_push.yaml#L92-L93)

---

*Error when adding tag with a slash:
```sh
docker build -t quay.io/ohsu-comp-bio/pod:feature/foo .
[+] Building 0.0s (0/0)                                                                                                                                                 docker:desktop-linux
ERROR: invalid tag "quay.io/ohsu-comp-bio/aced-etl-job:feature/foo": invalid reference format
```