### PR TITLE
TKEDTE-316: g3t Error handling on jsonschemagraph creation

### DIFF
--- a/etl-job/Dockerfile
+++ b/etl-job/Dockerfile
@@ -51,7 +51,7 @@ RUN source venv/bin/activate && pip install "aced-submission==0.0.9rc37"
     
 RUN git clone https://github.com/bmeg/iceberg.git && \
 	cd iceberg && \
-	git checkout feature/FHIR-resource-type
+	git checkout feature/substance-and-group
 
 #Add jsonschemagraph exe to image
 RUN wget https://github.com/bmeg/jsonschemagraph/releases/download/v0.0.2/jsonschemagraph-linux.amd64 -P /usr/local/bin/

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -213,7 +213,8 @@ def _load_all(study: str,
         output['logs'].append(f"Simplifying study: {file_path}")
 
         # call jsonschemagraph to create edges and vertices
-        subprocess.run(["jsonschemagraph", "gen-dir", "iceberg/schemas/graph", f"{file_path}", f"{extraction_path}","--project_id", f"{project_id}","--gzip_files"], check=True)
+        graph_gen_cmd = ["jsonschemagraph", "gen-dir", "iceberg/schemas/graph", f"{file_path}", f"{extraction_path}","--project_id", f"{project_id}","--gzip_files"]
+        subprocess.run(graph_gen_cmd, check=True, capture_output=True)
 
         bulk_load(_get_grip_service(), "CALIPER",f"{program}-{project}", extraction_path, output, _get_token())
 
@@ -269,9 +270,7 @@ def _load_all(study: str,
         final_error = f"ERROR: Unable to generate valid jsonschema graph from {file_path} to {extraction_path} for project ID {project_id}"
         output['logs'].append(final_error)
         print(final_error)
-        print("see logs directory for any additional details")
-
-        return False
+        print("see saved logs for more details")
 
     # all other exceptions
     except Exception as e:

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -256,9 +256,10 @@ def _load_all(study: str,
 
         # print final error
         final_error = f"ERROR: Unable to generate valid jsonschema graph from {file_path} to {extraction_path} for project ID {project_id}"
+        exception.stdout.append(f"\n{final_error}")
         output['logs'].append(final_error)
-        print(final_error)
-        raise Exception(final_error)
+        print(f"[out] {final_error}")
+        raise
 
     # when making changes to Elasticsearch
     except OpenSearchException as e:

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -258,7 +258,7 @@ def _load_all(study: str,
         final_error = f"ERROR: Unable to generate valid jsonschema graph from {file_path} to {extraction_path} for project ID {project_id}"
         output['logs'].append(final_error)
         print(final_error)
-        raise
+        raise Exception(final_error)
 
     # when making changes to Elasticsearch
     except OpenSearchException as e:
@@ -361,7 +361,8 @@ def _put(input_data: dict,
     # check permissions
     can_create = _can_create(output, program, project, user)
     output['logs'].append(f"CAN CREATE: {can_create}")
-    assert can_create, f"No create permissions on {program}"
+    if not can_create:
+        raise Exception(f"401: No permissions to create project {project} on program {program}. \nYou can view your project-level permissions with g3t ping")
     assert 'push' in input_data, "input data must contain a `push`"
     for commit in input_data['push']['commits']:
         assert 'object_id' in commit, "commit must contain an `object_id`"

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -290,6 +290,7 @@ def _load_all(study: str,
     return True
 
 
+# TODO: do we want to delete this as well? (TKEDTE-316)
 def _get(output: dict,
          program: str,
          project: str,
@@ -361,7 +362,7 @@ def main():
     # note, only the last output (a line in stdout with `[out]` prefix) is returned to the caller
 
     # output['env'] = {k: v for k, v in os.environ.items()}
-
+    
     input_data = _input_data()
     print(f"[out] {json.dumps(input_data, separators=(',', ':'))}")
     program, project = _get_program_project(input_data)
@@ -377,19 +378,19 @@ def main():
     if method.lower() == 'put':
         # read from bucket, write to fhir store
         _put(input_data, output, program, project, user, schema)
-        # after pushing commits, create a snapshot file
-        object_id = _get(output, program, project, user, auth)
-        output['snapshot'] = {'object_id': object_id}
     elif method.lower() == 'get':
+        
+        # TODO: should this be removed as well? (TKEDTE-316)
         # read fhir store, write to bucket
         object_id = _get(output, program, project, user, auth)
         output['object_id'] = object_id
     elif method.lower() == 'delete':
         _empty_project(output, program, project, user, dictionary_path=schema,
-                       config_path="config.yaml")
+                    config_path="config.yaml")
 
     else:
         raise Exception(f"unknown method {method}")
+
 
     # note, only the last output (a line in stdout with `[out]` prefix) is returned to the caller
     print(f"[out] {json.dumps(output, separators=(',', ':'))}")

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -352,7 +352,6 @@ def main():
     else:
         raise Exception(f"unknown method {method}")
 
-
     # note, only the last output (a line in stdout with `[out]` prefix) is returned to the caller
     _write_output_to_client(output)
 
@@ -368,9 +367,11 @@ def _put(input_data: dict,
     can_create = _can_create(output, program, project, user)
     output['logs'].append(f"CAN CREATE: {can_create}")
     if not can_create:
-        error_log = f"401: No permissions to create project {project} on program {program}. \nYou can view your project-level permissions with g3t ping"
+        error_log = f"ERROR 401: No permissions to create project {project} on program {program}. \nYou can view your project-level permissions with g3t ping"
         output["logs"].append(error_log)
+        _write_output_to_client(output)
         raise Exception(error_log)
+    
     assert 'push' in input_data, "input data must contain a `push`"
     for commit in input_data['push']['commits']:
         assert 'object_id' in commit, "commit must contain an `object_id`"

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -258,7 +258,7 @@ def _load_all(study: str,
         final_error = f"ERROR: Unable to generate valid jsonschema graph from {file_path} to {extraction_path} for project ID {project_id}"
         # exception.stdout.append(f"\n{final_error}")
         output['logs'].append(final_error)
-        print(f"[out] {final_error}")
+        print(f"[out] {json.dumps(output, separators=(',', ':'))}")
         raise
 
     # when making changes to Elasticsearch

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -256,7 +256,7 @@ def _load_all(study: str,
 
         # print final error
         final_error = f"ERROR: Unable to generate valid jsonschema graph from {file_path} to {extraction_path} for project ID {project_id}"
-        exception.stdout.append(f"\n{final_error}")
+        # exception.stdout.append(f"\n{final_error}")
         output['logs'].append(final_error)
         print(f"[out] {final_error}")
         raise

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -350,27 +350,6 @@ def _empty_project(output: dict,
 
 
 def main():
-    ######## DELETE AFTER TEST USE ##############
-
-    auth = 	_auth()
-    user = _user(auth)
-    output = {'user': user['email'], 'files': [], 'logs': []}
-
-    schema = None
-    if schema is None:
-        schema = 'https://aced-public.s3.us-west-2.amazonaws.com/aced-test.json'
-        output['logs'].append(f"DICTIONARY_URL not found in environment using {schema}")
-
-    print("HELLO")
-    try:
-        # FIXME: the below can be changed as needed
-        _load_all("<study_name>", "<project_id>", output, "META", schema, "work")
-    except Exception as e:
-        print("Exception:", str(e))
-
-    exit()
-    ######## DELETE AFTER TEST USE ##############
-
     token = _get_token()
     auth = _auth(token)
 

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -336,6 +336,27 @@ def _empty_project(output: dict,
 
 
 def main():
+    ######## DELETE AFTER TEST USE ##############
+
+    auth = 	_auth()
+    user = _user(auth)
+    output = {'user': user['email'], 'files': [], 'logs': []}
+
+    schema = None
+    if schema is None:
+        schema = 'https://aced-public.s3.us-west-2.amazonaws.com/aced-test.json'
+        output['logs'].append(f"DICTIONARY_URL not found in environment using {schema}")
+
+    print("HELLO")
+    try:
+        # FIXME: the below can be changed as needed
+        _load_all("<study_name>", "<project_id>", output, "META", schema, "work")
+    except Exception as e:
+        print("Exception:", str(e))
+
+    exit()
+    ######## DELETE AFTER TEST USE ##############
+
     token = _get_token()
     auth = _auth(token)
 

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -215,7 +215,7 @@ def _load_all(study: str,
         # call jsonschemagraph to create edges and vertices
         subprocess.run(["jsonschemagraph", "gen-dir", "iceberg/schemas/graph", f"{file_path}", f"{extraction_path}","--project_id", f"{project_id}","--gzip_files"], check=True)
 
-        bulk_load(_get_grip_service(), "CALIPER",f"{program}-{project}", extraction_path, output, _auth().get_access_token())
+        bulk_load(_get_grip_service(), "CALIPER",f"{program}-{project}", extraction_path, output, _get_token())
 
         assert pathlib.Path(work_path).exists(), f"Directory {work_path} does not exist."
         work_path = pathlib.Path(work_path)

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -216,11 +216,12 @@ def _load_all(study: str,
         try:
             result = subprocess.run(["jsonschemagraph", "gen-dir", "iceberg/schemas/graph", f"{file_path}", f"{extraction_path}","--project_id", f"{project_id}","--gzip_files"])
         except Exception as err:
+            output['logs'].append("TRACEBACK:", traceback.print_tb(err.__traceback__))
+            output['logs'].append("COMMAND ERROR:", err)
             output['logs'].append(f"ERROR: Unable to generate jsonschema graph from {file_path} to {extraction_path} for project ID {project_id}")
-            output['logs'].append(traceback.print_tb(err.__traceback__))
-            if result.stderr:
+            if result and result.stderr:
                 output['logs'].append(result.stderr.read().decode())
-            if result.stdout:
+            if result and result.stdout:
                 output['logs'].append(result.stdout.read().decode())
             return False
         


### PR DESCRIPTION
See [TKEDTE-316](https://jirabp.ohsu.edu/browse/TKEDTE-316) for more info.

**Acceptance Criteria**
1. Pushing SMMART data to an _empty project_ with invalid dates...
    - causes g3t to error out on jsonschema validation with a useful error message
    - additional logs are captured in logs/publish.logs that accurately describe the error
1. SMMART data with valid dates can be pushed to an _empty project_ and uploaded successfully without error
1. Other metadata has been successful pushed (eg gdc_lung) pushed to test backward compatibility
1. Integration tests pass for full submission workflow