### PR TITLE
Col name prefixes

### DIFF
--- a/etl-job/Dockerfile
+++ b/etl-job/Dockerfile
@@ -31,7 +31,7 @@ COPY ./requirements.txt /root
 RUN source venv/bin/activate && pip install -r requirements.txt
 
 # move these out of requirements.txt, so that builds are quicker when we change
-RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc23"
+RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc24"
 RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc18"
 ENV PATH="/usr/local/bin:$PATH"
 

--- a/etl-job/Dockerfile
+++ b/etl-job/Dockerfile
@@ -31,7 +31,7 @@ COPY ./requirements.txt /root
 RUN source venv/bin/activate && pip install -r requirements.txt
 
 # move these out of requirements.txt, so that builds are quicker when we change
-RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc22"
+RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc23"
 RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc14"
 ENV PATH="/usr/local/bin:$PATH"
 

--- a/etl-job/Dockerfile
+++ b/etl-job/Dockerfile
@@ -32,7 +32,7 @@ RUN source venv/bin/activate && pip install -r requirements.txt
 
 # move these out of requirements.txt, so that builds are quicker when we change
 RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc23"
-RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc15"
+RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc16"
 ENV PATH="/usr/local/bin:$PATH"
 
 

--- a/etl-job/Dockerfile
+++ b/etl-job/Dockerfile
@@ -32,7 +32,7 @@ RUN source venv/bin/activate && pip install -r requirements.txt
 
 # move these out of requirements.txt, so that builds are quicker when we change
 RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc23"
-RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc16"
+RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc17"
 ENV PATH="/usr/local/bin:$PATH"
 
 

--- a/etl-job/Dockerfile
+++ b/etl-job/Dockerfile
@@ -32,7 +32,7 @@ RUN source venv/bin/activate && pip install -r requirements.txt
 
 # move these out of requirements.txt, so that builds are quicker when we change
 RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc23"
-RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc17"
+RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc18"
 ENV PATH="/usr/local/bin:$PATH"
 
 

--- a/etl-job/Dockerfile
+++ b/etl-job/Dockerfile
@@ -32,7 +32,7 @@ RUN source venv/bin/activate && pip install -r requirements.txt
 
 # move these out of requirements.txt, so that builds are quicker when we change
 RUN source venv/bin/activate && pip install "gen3_tracker==0.0.7rc23"
-RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc14"
+RUN source venv/bin/activate && pip install "aced-submission==0.0.10rc15"
 ENV PATH="/usr/local/bin:$PATH"
 
 

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -19,6 +19,9 @@ from gen3_tracker.meta.dataframer import LocalFHIRDatabase
 
 logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 
+# Define the keys in one place at the top of the file
+INDEX_NAMES = ["research_subject", "specimen", "document_reference", "medication_administration", "group_member"]
+
 
 def _get_token() -> str | None:
     """Get ACCESS_TOKEN from environment"""
@@ -214,20 +217,17 @@ def _load_all(hostname,
         db = LocalFHIRDatabase(db_name=db_path)
         db.bulk_insert_data(resources=get_project_data(hostname, _get_graphName(), f"{program}-{project}", output, _get_token(), 1024*1024))
 
+        # associate index with generator function, eg "specimen": db.flattened_specimens
         index_generator_dict = {
             # index name needs to match column prefix coming off of the generators otherwise this will fail
-            'research_subject': db.flattened_research_subjects,
-            'specimen': db.flattened_specimens,
-            'document_reference': db.flattened_document_references,
-            "medication_administration": db.flattened_medication_administrations,
-            "group_member": db.flattened_group_members,
+            index: getattr(db, f"flattened_{index}s") for index in INDEX_NAMES
         }
 
         print("loading opensearch...")
         output["logs"].append("loading opensearch...")
 
         # To ensure differences in the dataframer versions do not conflict, clear the project, and reload the project.
-        for index in index_generator_dict.keys():
+        for index in INDEX_NAMES:
             meta_flat_delete(project_id=f"{program}-{project}", index=index)
 
         for index, generator in index_generator_dict.items():
@@ -286,7 +286,7 @@ def _empty_project(hostname,
                     output=output, access_token=_get_token())
         output['logs'].append(f"EMPTIED graph for {program}-{project}")
 
-        for index in ["researchsubject", "specimen", "file"]:
+        for index in INDEX_NAMES:
             meta_flat_delete(project_id=f"{program}-{project}", index=index)
         output['logs'].append(f"EMPTIED flat for {program}-{project}")
 

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import traceback
+import inflection
 
 from aced_submission.meta_flat_load import DEFAULT_ELASTIC, load_flat
 from aced_submission.meta_flat_load import delete as meta_flat_delete
@@ -229,8 +230,14 @@ def _load_all(hostname,
             meta_flat_delete(project_id=f"{program}-{project}", index=index)
 
         for index, generator in index_generator_dict.items():
+
+            prefix = inflection.underscore(index)
+            prefixed_generator = (
+                {f"{prefix}_{k}": v for k, v in record.items()}
+                for record in generator()
+            )
             load_flat(project_id=f"{program}-{project}", index=index,
-                      generator=generator(),
+                      generator=prefixed_generator,
                       limit=None, elastic_url=DEFAULT_ELASTIC,
                       output_path=None)
 

--- a/etl-job/fhir_import_export.py
+++ b/etl-job/fhir_import_export.py
@@ -215,11 +215,12 @@ def _load_all(hostname,
         db.bulk_insert_data(resources=get_project_data(hostname, _get_graphName(), f"{program}-{project}", output, _get_token(), 1024*1024))
 
         index_generator_dict = {
-            'researchsubject': db.flattened_research_subjects,
+            # index name needs to match column prefix coming off of the generators otherwise this will fail
+            'research_subject': db.flattened_research_subjects,
             'specimen': db.flattened_specimens,
-            'file': db.flattened_document_references,
-            "medicationadministration": db.flattened_medication_administrations,
-            "groupmember": db.flattened_group_members,
+            'document_reference': db.flattened_document_references,
+            "medication_administration": db.flattened_medication_administrations,
+            "group_member": db.flattened_group_members,
         }
 
         print("loading opensearch...")


### PR DESCRIPTION
Add col name prefixes to enable proper use of cross tab filtering in explorer page 

Deployment Steps: 
- use ETL image tag  ```feat_add-prefixes```
- change indices section of guppy config to
```yaml
indices:
  - index: document_reference
    type: document_reference
  - index: research_subject
    type: research_subject
  - index: specimen
    type: specimen
  - index: medication_administration
    type: medication_administration
  - index: group_member
    type: group_member
configIndex: calypr_array-config
  ```


in order for dataframer table names to match elastic index names so that index prefixing can be done in submission ETL package based off of index name.

You will have to rebuild all elastic search indices since the index names have changed 

Relevant PRs:
https://github.com/ACED-IDP/submission/pull/37
https://github.com/ACED-IDP/gen3_util/pull/146/files
https://source.ohsu.edu/CBDS/IDP-Frontend/pull/29 -- See updated config files for explorer page 